### PR TITLE
Show red UI badges, and a dock badge, on important notifications

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -65,6 +65,8 @@ window.AppView = window.BackchatView.extend({
           self.addChannelView(server.url, channelName);
         });
       });
+      // Add the user's specified keywords
+      self.keywords.concat(settings.keywords);
     },
     'channel:joined': function(e){
       this.addServerButton(e.server);
@@ -76,6 +78,7 @@ window.AppView = window.BackchatView.extend({
       v.addStageDirection({ userJoined: e.user });
       v.addUserButton(e.user);
       v.sortUserButtons();
+      this.keywords.append(e.user);
     },
     'channel:parted': function(e){
       this.addServerButton(e.server);
@@ -110,12 +113,19 @@ window.AppView = window.BackchatView.extend({
     },
     'server:whois': function(e){
       window.activeChannel.addServerMessage(JSON.stringify(e.info, null, 2));
+    },
+    'nick:changed': function(e){
+      this.keywords = _.reject(this.keywords, function(keyword){
+        return keyword === e.oldNick;
+      });
+      this.keywords.append(e.newNick);
     }
   },
 
   channelViews: {}, // Store channels views in here, keyed by serverUrl+channelName
   serverButtonViews: {}, // Keyed by serverUrl
   channelButtonViews: {}, // Keyed by serverUrl+channelName
+  keywords: [], // Words that should trigger a notification
 
   addChannelView: function(serverUrl, channelName){
     var id = serverUrl + ' ' + channelName;

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -104,6 +104,17 @@ ipc.on('client:ready', function(){
     );
   }
 
+}).on('client:incrementDockBadge', function(){
+  var currentValue = 0;
+  if( _.isFinite(app.dock.getBadge()) ){
+    currentValue = parseFloat(app.dock.getBadge());
+  }
+  var newValueAsString = '' + (1 + currentValue);
+  app.dock.setBadge(newValueAsString);
+
+}).on('client:clearDockBadge', function(){
+  app.dock.setBadge('');
+
 });
 
 pool.on('irc:registering', function(e){

--- a/src/templates/default-settings.json
+++ b/src/templates/default-settings.json
@@ -8,8 +8,8 @@
       "userName": "nodebot122",
       "realName": "Node Bot 122",
       "autoConnect": true,
-      "channels": [ "#bots" ],
-      "keywords": [ "tannoy" ]
+      "channels": [ "#bots" ]
     }
-  ]
+  ],
+  "keywords": [ "tannoy" ]
 }


### PR DESCRIPTION
Fixes #10 and #5.

For simplicity, the `"keywords"` setting now operates across all server connections, which is why it now lives at the top level of `settings.json` rather than inside a `"server"` block.