### PR TITLE
Show users’ away status

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -339,8 +339,19 @@ window.UserButtonView = window.BackchatView.extend({
 
   ipcEvents: {
     'nick:changed': function(details){
-      this.options.nick = details.newNick;
-      this.$el.text(details.newNick);
+      if(details.oldNick == this.options.nick){
+        this.options.nick = details.newNick;
+        this.$el.text(details.newNick);
+      }
+    },
+    'server:userStatus': function(details){
+      if(details.nick == this.options.nick){
+        if(details.away == true) {
+          this.$el.addClass('away');
+        } else if(details.away == false){
+          this.$el.removeClass('away');
+        }
+      }
     }
   }
 });

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -286,6 +286,17 @@ window.ChannelButtonView = window.BackchatView.extend({
       if(this.isRightChannel(e) && this.isAboutMe(e)){
         this.$el.addClass('unjoined');
       }
+    },
+    'server:userStatus': function(details){
+      if(details.server == this.options.serverUrl) {
+        if(details.nick == this.options.channelName){
+          if(details.away == true) {
+            this.$el.addClass('away');
+          } else if(details.away == false){
+            this.$el.removeClass('away');
+          }
+        }
+      }
     }
   },
 

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -339,17 +339,21 @@ window.UserButtonView = window.BackchatView.extend({
 
   ipcEvents: {
     'nick:changed': function(details){
-      if(details.oldNick == this.options.nick){
-        this.options.nick = details.newNick;
-        this.$el.text(details.newNick);
+      if(details.server == this.options.serverUrl) {
+        if(details.oldNick == this.options.nick){
+          this.options.nick = details.newNick;
+          this.$el.text(details.newNick);
+        }
       }
     },
     'server:userStatus': function(details){
-      if(details.nick == this.options.nick){
-        if(details.away == true) {
-          this.$el.addClass('away');
-        } else if(details.away == false){
-          this.$el.removeClass('away');
+      if(details.server == this.options.serverUrl) {
+        if(details.nick == this.options.nick){
+          if(details.away == true) {
+            this.$el.addClass('away');
+          } else if(details.away == false){
+            this.$el.removeClass('away');
+          }
         }
       }
     }

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -2,7 +2,7 @@ var ipc = require('ipc');
 
 // By default, EventEmitter will raise a warning when more than 10
 // IPC listeners are attached at the same time. We tend to hit the
-// limit when adding nick:changed listeners to a batch of users in
+// limit when adding user:nickChanged listeners to a batch of users in
 // a newly-joined channel. This ups the limit to 100.
 ipc.setMaxListeners(100);
 
@@ -122,7 +122,7 @@ window.AppView = window.BackchatView.extend({
         e.timestamp
       );
     },
-    'nick:changed': function(e){
+    'user:nickChanged': function(e){
       this.keywords = _.reject(this.keywords, function(keyword){
         return keyword === e.oldNick;
       });
@@ -287,7 +287,7 @@ window.ChannelButtonView = window.BackchatView.extend({
         this.$el.addClass('unjoined');
       }
     },
-    'server:userStatus': function(details){
+    'user:userStatus': function(details){
       if(details.server == this.options.serverUrl) {
         if(details.nick == this.options.channelName){
           if(details.away == true) {
@@ -349,7 +349,7 @@ window.UserButtonView = window.BackchatView.extend({
   },
 
   ipcEvents: {
-    'nick:changed': function(details){
+    'user:nickChanged': function(details){
       if(details.server == this.options.serverUrl) {
         if(details.oldNick == this.options.nick){
           this.options.nick = details.newNick;
@@ -357,7 +357,7 @@ window.UserButtonView = window.BackchatView.extend({
         }
       }
     },
-    'server:userStatus': function(details){
+    'user:userStatus': function(details){
       if(details.server == this.options.serverUrl) {
         if(details.nick == this.options.nick){
           if(details.away == true) {

--- a/src/client/sass/_sidebar.scss
+++ b/src/client/sass/_sidebar.scss
@@ -50,6 +50,14 @@
         color: rgba(255,255,255,0.5);
       }
     }
+
+    &.away {
+      color: inherit;
+
+      &:focus {
+        color: rgba(255,255,255,0.7);
+      }
+    }
   }
 
   .loading {

--- a/src/server/connection-pool.js
+++ b/src/server/connection-pool.js
@@ -81,7 +81,7 @@ module.exports = ConnectionPool = (function(){
         user: nick,
         myNick: client.nick
       });
-      refreshUserStatuses({ oneOff: true });
+      client.send('WHO', channel);
 
     }).addListener('part', function(channel, nick, reason, message){
       // console.log('[irc event]', '[part]', channel, nick, reason);
@@ -179,6 +179,10 @@ module.exports = ConnectionPool = (function(){
       self.emit('irc:whois', {
         server: connectionSettings.url,
         info: info
+      });
+      self.emit('irc:userStatus', {
+        nick: info.nick,
+        away: ('away' in info)
       });
 
     }).addListener('channellist_start', function(){

--- a/src/server/connection-pool.js
+++ b/src/server/connection-pool.js
@@ -39,6 +39,8 @@ module.exports = ConnectionPool = (function(){
         server: connectionSettings.url,
         message: message
       });
+
+      // Join channels from config file if requested
       if(connectionSettings.autoConnect && connectionSettings.channels){
         _.each(connectionSettings.channels, function(channelName){
           client.join(channelName);
@@ -48,6 +50,10 @@ module.exports = ConnectionPool = (function(){
           });
         });
       }
+
+      // Start the function that checks for user away statuses
+      refreshUserStatuses();
+
     }).addListener('names', function(channel, nicks){
       // console.log('[irc event]', '[names]', channel, nicks);
       self.emit('irc:names', {
@@ -57,6 +63,7 @@ module.exports = ConnectionPool = (function(){
           return a.localeCompare(b, 'en', { sensitivity: 'base' });
         })
       });
+
     }).addListener('topic', function(channel, topic, nick, message){
       // console.log('[irc event]', '[topic]', channel, topic, nick);
       self.emit('irc:topic', {
@@ -65,6 +72,7 @@ module.exports = ConnectionPool = (function(){
         topic: topic,
         user: nick
       });
+
     }).addListener('join', function(channel, nick, message){
       // console.log('[irc event]', '[join]', channel, nick);
       self.emit('irc:join', {
@@ -73,6 +81,8 @@ module.exports = ConnectionPool = (function(){
         user: nick,
         myNick: client.nick
       });
+      refreshUserStatuses({ oneOff: true });
+
     }).addListener('part', function(channel, nick, reason, message){
       // console.log('[irc event]', '[part]', channel, nick, reason);
       self.emit('irc:part', {
@@ -82,6 +92,7 @@ module.exports = ConnectionPool = (function(){
         reason: reason,
         myNick: client.nick
       });
+
     }).addListener('quit', function(nick, reason, channels, message){
       // console.log('[irc event]', '[quit]', nick, reason, channels);
       self.emit('irc:quit', {
@@ -91,6 +102,7 @@ module.exports = ConnectionPool = (function(){
         channels: channels,
         myNick: client.nick
       });
+
     }).addListener('kick', function(channel, nick, by, reason, message){
       console.log('[irc event]', '[kick]', channel, nick, by, reason);
       self.emit('irc:kick', {
@@ -101,6 +113,7 @@ module.exports = ConnectionPool = (function(){
         reason: reason,
         myNick: client.nick
       });
+
     }).addListener('kill', function(nick, reason, channels, message){
       console.log('[irc event]', '[kill]', nick, reason, channels);
       self.emit('irc:kill', {
@@ -110,6 +123,7 @@ module.exports = ConnectionPool = (function(){
         channels: channels,
         myNick: client.nick
       });
+
     }).addListener('message', function(nick, to, text, message){
       // console.log('[irc event]', '[message]', nick, to, text);
       self.emit('irc:message', {
@@ -119,6 +133,7 @@ module.exports = ConnectionPool = (function(){
         messageText: text,
         myNick: client.nick
       });
+
     }).addListener('selfMessage', function(to, text){
       // console.log('[irc event]', '[selfMessage]', to, text);
       self.emit('irc:message', {
@@ -128,6 +143,7 @@ module.exports = ConnectionPool = (function(){
         messageText: text,
         myNick: client.nick
       });
+
     }).addListener('notice', function(nick, to, text, message){
       console.log('[irc event]', '[notice]', nick, to, text);
       self.emit('irc:notice', {
@@ -137,6 +153,7 @@ module.exports = ConnectionPool = (function(){
         messageText: text,
         myNick: client.nick
       });
+
     }).addListener('nick', function(oldnick, newnick, channels, message){
       // console.log('[irc event]', '[nick]', oldnick, newnick, channels);
       self.emit('irc:changedNick', {
@@ -146,6 +163,7 @@ module.exports = ConnectionPool = (function(){
         channels: channels,
         myNick: client.nick
       });
+
     }).addListener('action', function(from, to, text, message){
       // console.log('[irc event]', '[action]', from, to, text);
       self.emit('irc:action', {
@@ -155,21 +173,58 @@ module.exports = ConnectionPool = (function(){
         actionText: text,
         myNick: client.nick
       });
+
     }).addListener('whois', function(info){
       // console.log('[irc event]', '[whois]', info);
       self.emit('irc:whois', {
         server: connectionSettings.url,
         info: info
       });
+
     }).addListener('channellist_start', function(){
       console.log('[irc event]', '[channellist_start]');
+
     }).addListener('channellist_item', function(){
       console.log('[irc event]', '[channellist_item]');
+
     }).addListener('channellist', function(){
       console.log('[irc event]', '[channellist]');
+
     }).addListener('raw', function(message){
       console.log('[irc event]', '[raw]', message);
+
+      if(message.command == 'rpl_whoreply'){
+        self.emit('irc:userStatus', {
+          nick: message.args[5],
+          away: message.args[6].startsWith('G')
+        });
+      } else if(message.command == 'rpl_nowaway'){
+        self.emit('irc:userStatus', {
+          nick: message.args[0],
+          away: true
+        });
+      } else if(message.command == 'rpl_unaway'){
+        self.emit('irc:userStatus', {
+          nick: message.args[0],
+          away: false
+        });
+      }
     });
+
+    var refreshUserStatuses = function refreshUserStatuses(options){
+      options = _.extend({}, options);
+
+      // client.chans should be an object of channels the
+      // user is currently occupying, keyed by channelName.
+      _.each(client.chans, function(channelInfo, channelName){
+        client.send('WHO', channelName);
+      });
+
+      if(!options.oneOff){
+        setTimeout(refreshUserStatuses, 10000);
+      }
+    }
+
     self.connections[connectionSettings.url] = client;
   };
 

--- a/src/server/connection-pool.js
+++ b/src/server/connection-pool.js
@@ -181,6 +181,7 @@ module.exports = ConnectionPool = (function(){
         info: info
       });
       self.emit('irc:userStatus', {
+        server: connectionSettings.url,
         nick: info.nick,
         away: ('away' in info)
       });
@@ -199,16 +200,19 @@ module.exports = ConnectionPool = (function(){
 
       if(message.command == 'rpl_whoreply'){
         self.emit('irc:userStatus', {
+          server: connectionSettings.url,
           nick: message.args[5],
           away: message.args[6].startsWith('G')
         });
       } else if(message.command == 'rpl_nowaway'){
         self.emit('irc:userStatus', {
+          server: connectionSettings.url,
           nick: message.args[0],
           away: true
         });
       } else if(message.command == 'rpl_unaway'){
         self.emit('irc:userStatus', {
+          server: connectionSettings.url,
           nick: message.args[0],
           away: false
         });

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -211,9 +211,9 @@ pool.on('irc:registering', function(e){
 
 }).on('irc:changedNick', function(e){
   e.timestamp = ISOTimestamp();
-  console.log('nick:changed', JSON.stringify(e, null, 2));
-  mainWindow.webContents.send('nick:changed', e);
-  saveToLog('nick:changed', e);
+  console.log('user:nickChanged', JSON.stringify(e, null, 2));
+  mainWindow.webContents.send('user:nickChanged', e);
+  saveToLog('user:nickChanged', e);
 
 }).on('irc:whois', function(e){
   e.timestamp = ISOTimestamp();
@@ -221,8 +221,8 @@ pool.on('irc:registering', function(e){
   mainWindow.webContents.send('server:whois', e);
 
 }).on('irc:userStatus', function(e){
-  console.log('server:userStatus', JSON.stringify(e, null, 2));
-  mainWindow.webContents.send('server:userStatus', e);
+  console.log('user:userStatus', JSON.stringify(e, null, 2));
+  mainWindow.webContents.send('user:userStatus', e);
 
 });
 
@@ -274,7 +274,7 @@ var saveToLog = function saveToLog(type, e){
   } else if(type == 'action:sent'){
     row += '• ' + e.fromUser + ' ' + e.actionText;
     var channel = e.toUserOrChannel;
-  } else if(type == 'nick:changed'){
+  } else if(type == 'user:nickChanged'){
     row += e.oldNick + ' is now known as ' + e.newNick;
     var channel = e.channel;
   }

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -111,6 +111,12 @@ ipc.on('client:ready', function(){
     );
   }
 
+}).on('client:refreshUserStatusesForChannel', function(e, args){
+  pool.getConnection(args.serverUrl).send('WHO', args.channelName);
+
+}).on('client:refreshUserStatus', function(e, args){
+  pool.getConnection(args.serverUrl).send('WHOIS', args.nick);
+
 }).on('client:incrementDockBadge', function(){
   var currentValue = 0;
   if( _.isFinite(app.dock.getBadge()) ){

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -214,6 +214,10 @@ pool.on('irc:registering', function(e){
   console.log('server:whois', JSON.stringify(e, null, 2));
   mainWindow.webContents.send('server:whois', e);
 
+}).on('irc:userStatus', function(e){
+  console.log('server:userStatus', JSON.stringify(e, null, 2));
+  mainWindow.webContents.send('server:userStatus', e);
+
 });
 
 var getSettings = function getSettings(cb){


### PR DESCRIPTION
Closes #21.

Away status is now polled for every 10 seconds, for all users present in all currently joined channels. Away users are shown greyed out in the user list, and (if a direct message channel is open with the user) in the main channel list.

Comings and goings are not recorded in the scrollback or logs. See reasoning in #21.