### PR TITLE
Leaving a channel

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -235,6 +235,9 @@ window.AppView = window.BackchatView.extend({
     },
     'application:leaveCurrentChannel': function(){
       window.activeChannel.close();
+    },
+    'application:leaveChannel': function(e){
+      this.channelViews[e.serverUrl + ' ' + e.channelName].close();
     }
   },
 
@@ -350,6 +353,12 @@ window.ChannelButtonView = window.BackchatView.extend({
     'click': function(){
       var id = this.options.serverUrl + ' ' + this.options.channelName;
       window.app.channelViews[id].focus();
+    },
+    'contextmenu': function(){
+      ipc.send('client:showChannelButtonContextMenu', {
+        serverUrl: this.options.serverUrl,
+        channelName: this.options.channelName
+      });
     }
   },
 

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -604,6 +604,14 @@ window.ChannelView = window.BackchatView.extend({
   close: function(){
     var id = this.options.serverUrl + ' ' + this.options.channelName;
 
+    // Formally leave the channel on IRC
+    if(this.isRealChannel()){
+      ipc.send('client:leaveChannel', {
+        serverUrl: this.options.serverUrl,
+        channelName: this.options.channelName,
+      });
+    }
+
     // Switch to the nearest channel in the sidebar.
     var $nearestChannelButtonView = this.getChannelButtonView().$el.prev('button');
     if($nearestChannelButtonView.length == 0){
@@ -644,6 +652,12 @@ window.ChannelView = window.BackchatView.extend({
       self.addUserButton(user);
     });
     self.sortUserButtons();
+  },
+
+  isRealChannel: function(){
+    // Useful for telling whether this is a real channel,
+    // or a just a private message session.
+    return this.options.channelName.startsWith('#');
   },
 
   addUserButton: function(nick){

--- a/src/client/sass/_channel.scss
+++ b/src/client/sass/_channel.scss
@@ -4,6 +4,10 @@
   &.active {
     display: flex;
   }
+
+  &.unjoined .channel__scrollback {
+    color: #666;
+  }
 }
 
 .channel__scrollback {

--- a/src/client/sass/_sidebar.scss
+++ b/src/client/sass/_sidebar.scss
@@ -42,7 +42,7 @@
     &.unjoined {
       color: mix($color-mac-sidebar-heading, $color-mac-sidebar-background, 50%);
 
-      &:focus {
+      &.active:focus {
         color: rgba(255,255,255,0.5);
       }
     }
@@ -50,7 +50,7 @@
     &.away {
       color: inherit;
 
-      &:focus {
+      &.active:focus {
         color: rgba(255,255,255,0.7);
       }
     }

--- a/src/client/sass/_sidebar.scss
+++ b/src/client/sass/_sidebar.scss
@@ -43,7 +43,6 @@
       color: mix($color-mac-sidebar-heading, $color-mac-sidebar-background, 50%);
 
       &:focus {
-        background-color: $color-mac-sidebar-selected;
         color: rgba(255,255,255,0.5);
       }
     }

--- a/src/server/app-menu.js
+++ b/src/server/app-menu.js
@@ -18,15 +18,15 @@ module.exports = ApplicationMenu = (function(){
   };
 
   ApplicationMenu.prototype.wireUpMenuItem = function(menu, command){
-    var _this = this;
+    var self = this;
+
     menu.click = function(){
-      _this.emit(command);
+      self.emit(command);
     };
   };
 
   ApplicationMenu.prototype.translateTemplate = function(template, pkgJson){
-    var emitter = this.emit;
-    var _this = this;
+    var self = this;
 
     _.each(template, function(item){
       item.metadata = item.metadata || {};
@@ -36,11 +36,11 @@ module.exports = ApplicationMenu = (function(){
       }
 
       if(item.command){
-        _this.wireUpMenuItem(item, item.command);
+        self.wireUpMenuItem(item, item.command);
       }
 
       if(item.submenu){
-        _this.translateTemplate(item.submenu, pkgJson);
+        self.translateTemplate(item.submenu, pkgJson);
       }
     });
 

--- a/src/server/app-menu.js
+++ b/src/server/app-menu.js
@@ -4,7 +4,6 @@ var Menu = require('menu');
 var _ = require('underscore-plus');
 var EventEmitter = require('events').EventEmitter;
 
-var menuJson = require('../templates/mac-menu.json');
 var ApplicationMenu;
 
 module.exports = ApplicationMenu = (function(){
@@ -13,12 +12,9 @@ module.exports = ApplicationMenu = (function(){
 
   // Class constructor
   function ApplicationMenu(options){
+    var menuJson = require(options.templateJson);
     this.template = this.translateTemplate(menuJson, options.pkgJson);
-  };
-
-  ApplicationMenu.prototype.attachToWindow = function(window){
     this.menu = Menu.buildFromTemplate(_.deepClone(this.template));
-    Menu.setApplicationMenu(this.menu);
   };
 
   ApplicationMenu.prototype.wireUpMenu = function(menu, command){

--- a/src/server/app-menu.js
+++ b/src/server/app-menu.js
@@ -17,7 +17,7 @@ module.exports = ApplicationMenu = (function(){
     this.menu = Menu.buildFromTemplate(_.deepClone(this.template));
   };
 
-  ApplicationMenu.prototype.wireUpMenu = function(menu, command){
+  ApplicationMenu.prototype.wireUpMenuItem = function(menu, command){
     var _this = this;
     menu.click = function(){
       _this.emit(command);
@@ -36,7 +36,7 @@ module.exports = ApplicationMenu = (function(){
       }
 
       if(item.command){
-        _this.wireUpMenu(item, item.command);
+        _this.wireUpMenuItem(item, item.command);
       }
 
       if(item.submenu){
@@ -46,6 +46,22 @@ module.exports = ApplicationMenu = (function(){
 
     return template;
   };
+
+  // Find menu items with the given key:value attributes
+  ApplicationMenu.prototype.find = function(attributes){
+    return _.where(this.menu.items, attributes);
+  };
+
+  // Find menu items by attribute, and then set other attributes on them.
+  // eg: menu.set({ id: "exampleItem" }, { enabled: false });
+  ApplicationMenu.prototype.set = function(findByAtrributes, setAttributes){
+    _.each(this.find(findByAtrributes), function(menuItem){
+      _.each(setAttributes, function(value, key){
+        menuItem[key] = value;
+      });
+    });
+    return this; // Enable chaining
+  }
 
   return ApplicationMenu;
 })();

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -77,6 +77,13 @@ app.on('ready', function() {
 
   channelButtonMenu.on('application:leaveChannel', function(){
     pool.getConnection(this.serverUrl).part(this.channelName);
+  }).on('application:joinChannel', function(){
+    pool.getConnection(this.serverUrl).join(this.channelName);
+  }).on('application:closeChannel', function(){
+    mainWindow.webContents.send('channel:close', {
+      serverUrl: this.serverUrl,
+      channelName: this.channelName
+    });
   }).on('application:showLogsForChannel', function(){
     showLogsForChannel({
       serverUrl: this.serverUrl,
@@ -194,6 +201,21 @@ ipc.on('client:ready', function(){
   // If it's a joined channel, option should be "Leave channel".
   // If it's an unjoined channel, options should be "Join channel"
   //   and "Remove from sidebar".
+  if(args.channelName.startsWith('#')){
+    if(args.joined){
+      channelButtonMenu.set({ id: 'closeChannel'}, { visible: false });
+      channelButtonMenu.set({ id: 'joinChannel'}, { visible: false });
+      channelButtonMenu.set({ id: 'leaveChannel'}, { visible: true });
+    } else {
+      channelButtonMenu.set({ id: 'closeChannel'}, { visible: true });
+      channelButtonMenu.set({ id: 'joinChannel'}, { visible: true });
+      channelButtonMenu.set({ id: 'leaveChannel'}, { visible: false });
+    }
+  } else {
+    channelButtonMenu.set({ id: 'closeChannel'}, { visible: true });
+    channelButtonMenu.set({ id: 'joinChannel'}, { visible: false });
+    channelButtonMenu.set({ id: 'leaveChannel'}, { visible: false });
+  }
   channelButtonMenu.serverUrl = args.serverUrl;
   channelButtonMenu.channelName = args.channelName;
   channelButtonMenu.menu.popup(mainWindow);

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -40,6 +40,8 @@ app.on('ready', function() {
     mainWindow.webContents.send('application:getActiveChannel', {
       ipcCallback: 'client:showLogsForChannel'
     });
+  }).on('application:leaveCurrentChannel', function(){
+    mainWindow.webContents.send('application:leaveCurrentChannel');
   });
 
   mainWindow = new BrowserWindow({

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -140,6 +140,10 @@ ipc.on('client:ready', function(){
     );
   }
 
+}).on('client:leaveChannel', function(e, args){
+  console.log('** client:leaveChannel **', args.serverUrl, '**', args.channelName, '**');
+  pool.getConnection(args.serverUrl).part(args.channelName);
+
 }).on('client:refreshUserStatusesForChannel', function(e, args){
   pool.getConnection(args.serverUrl).send('WHO', args.channelName);
 

--- a/src/templates/channel-menu.json
+++ b/src/templates/channel-menu.json
@@ -1,4 +1,7 @@
 [
-  { "label": "Show logs", "command": "application:showLogsForChannel" },
-  { "label": "Leave channel", "command": "application:leaveChannel" }
+  { "label": "Join channel", "id": "joinChannel", "command": "application:joinChannel" },
+  { "label": "Leave channel", "id": "leaveChannel", "command": "application:leaveChannel" },
+  { "label": "Remove from sidebar", "id": "closeChannel", "command": "application:closeChannel" },
+  { "type": "separator" },
+  { "label": "Show logs", "command": "application:showLogsForChannel" }
 ]

--- a/src/templates/channel-menu.json
+++ b/src/templates/channel-menu.json
@@ -1,0 +1,4 @@
+[
+  { "label": "Show logs", "command": "application:showLogsForChannel" },
+  { "label": "Leave channel", "command": "application:leaveChannel" }
+]


### PR DESCRIPTION
Wires up the "Leave channel" menu item to actually leave the current channel.

Also adds context menu to channels in the sidebar, with "Leave channel" and "Show logs" options, which do what you'd expect. This fixes #33.

"Leaving" a channel sends a `PART` command to the IRC server. The `channelView` and associated `channelButtonView` stay in the DOM, but are given a deactivated style.

"Removing from sidebar" removes the `channelView` from the DOM, along with its `userButtonViews` and `channelButtonView`.