### PR TITLE
Append image previews to messages, if URLs look like images

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -112,7 +112,25 @@ var wrapKeywords = function wrapKeywords(text, htmlTag){
 }
 
 var linkifyUrls = function linkifyUrls(text){
-  return Autolinker.link(text, {stripPrefix: false, hashtag: false});
+  var afterText = '';
+  var text = Autolinker.link(text, {
+    stripPrefix: false,
+    hashtag: false,
+    replaceFn: function(autolinker, match){
+      if(match.getType() == 'url'){
+        var link = document.createElement('a');
+        link.href = match.getUrl();
+        if(link.pathname.match(/[.](gif|png|jpg|jpeg)/i)){
+          afterText += '<a href="' + link.href + '" target="_blank"><img src="' + link.href + '"></a>';
+        }
+        return true; // Default autolinker behaviour
+      } else {
+        return true; // Default autolinker behaviour
+      }
+    }
+  });
+
+  return text + afterText;
 }
 
 // Prepare a string for display in the channel scrollback

--- a/src/client/sass/_channel.scss
+++ b/src/client/sass/_channel.scss
@@ -82,6 +82,14 @@
     position: absolute;
     left: $padding-scrollback-item;
   }
+
+  img {
+    display: block;
+    height: auto;
+    max-width: 100%;
+    border-radius: 3px;
+    margin-top: 1em;
+  }
 }
 
 .channel__stage-direction {


### PR DESCRIPTION
Fixes #2 by detecting links to URLs that contain an image file extension, and displaying the image inline below the message.

I have a feeling, once this gets inevitably expanded to other types of inline metadata (https://github.com/zarino/backchat/issues/3), we'll want this detection to be carried out by the server, and then sent to client as metadata alongside the message. But for now, adding it to the client is the simplest option, as the client already converts inline URLs to links.