### PR TITLE
Spellchecking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ To run the app using the Electron bootstrapper:
 
 ```
 npm install
+./node_modules/.bin/electron-rebuild
 npm start
 ```
+
+`electron-rebuild` must be run after you install or update packages, to ensure packages are compiled for an electron-compatible version of Node. (If you get errors like `Module version mismatch. Expected 44, got 14.` it’s because you’ve not run `electron-rebuild`.)
 
 `npm start` automatically compiles the Sass stylesheets, checks the JavaScript files for syntax errors, and—if both of those things passed successfully—starts Backchat in the Electron bootstrapper.
 

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "autolinker": "^0.18.1",
     "fs-extra": "^0.22.1",
     "irc": "~0.3.11",
+    "spellchecker": "^2.2.1",
     "underscore-plus": "^1.6.1"
   },
   "devDependencies": {
     "acorn": "^1.0.3",
     "chromedriver": "^2.15.0",
-    "electron-packager": "^3.1.0",
-    "electron-prebuilt": "^0.25.2",
+    "electron-packager": "^5.0.1",
+    "electron-prebuilt": "^0.30.2",
+    "electron-rebuild": "^0.2.5",
     "ircdjs": "git://github.com/alexyoung/ircd.js",
     "mocha": "~1.18.0",
     "promise": "^7.0.1",

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -1,4 +1,7 @@
 var ipc = require('ipc');
+var webframe = require('web-frame');
+
+var spellchecker = require('spellchecker');
 var Autolinker = require('autolinker');
 
 // By default, EventEmitter will raise a warning when more than 10
@@ -6,6 +9,13 @@ var Autolinker = require('autolinker');
 // limit when adding user:nickChanged listeners to a batch of users in
 // a newly-joined channel. This ups the limit to 100.
 ipc.setMaxListeners(100);
+
+// Enable spellchecking for message composition boxes.
+webframe.setSpellCheckProvider("en-GB", true, {
+  spellCheck: function(text) {
+    return ! spellchecker.isMisspelled(text);
+  }
+});
 
 // Use django-style templating in underscore.js
 // because my fat fingers can't learn angle brackets.


### PR DESCRIPTION
Fixes #44 by underlining misspelt words using the Mac's native spellchecker.

**However** there's no menu when you right-click the word, meaning there's no easy way to select a *correct* spelling from a list of suggestions. [The spellchecker library does provide this list](http://atom.github.io/node-spellchecker/) – but I'd need to construct the right-click menu myself.