### PR TITLE
Text context menus on right-click

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -260,6 +260,14 @@ window.AppView = window.BackchatView.extend({
         channelName: window.activeChannel.options.channelName,
         updatedTimestamp: window.activeChannel.updatedTimestamp
       });
+    },
+    'application:replaceSelectedWordWithSuggestion': function(e){
+      var $input = $('textarea:focus, input:focus');
+      var textBeforeSelection = $input.val().substring(0, $input[0].selectionStart);
+      var textAfterSelection = $input.val().substring($input[0].selectionEnd);
+      var newCaretPosition = textBeforeSelection.length + e.replacementText.length;
+      $input.val(textBeforeSelection + e.replacementText + textAfterSelection);
+      $input[0].setSelectionRange(newCaretPosition, newCaretPosition);
     }
   },
 
@@ -587,6 +595,21 @@ window.ChannelView = window.BackchatView.extend({
           $input.val('');
         }
       }
+    },
+    'contextmenu .channel__input': function(){
+      var spellingSuggestions;
+      var selectedText = window.getSelection().toString();
+      var numberOfWords = selectedText.split(' ').length;
+      if(numberOfWords == 1){
+        if(spellchecker.isMisspelled(selectedText)){
+          spellingSuggestions = spellchecker.getCorrectionsForMisspelling(selectedText);
+        }
+      }
+      ipc.send('client:showGenericTextContextMenu', {
+        spellingSuggestions: spellingSuggestions,
+        isEditable: true,
+        isRange: selectedText.length > 0
+      });
     }
   },
 

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -610,6 +610,13 @@ window.ChannelView = window.BackchatView.extend({
         isEditable: true,
         isRange: selectedText.length > 0
       });
+    },
+    'contextmenu .channel__scrollback': function(){
+      var selectedText = window.getSelection().toString();
+      ipc.send('client:showGenericTextContextMenu', {
+        isEditable: false,
+        isRange: selectedText.length > 0
+      });
     }
   },
 

--- a/src/server/native-menu.js
+++ b/src/server/native-menu.js
@@ -36,7 +36,7 @@ module.exports = NativeMenu = (function(){
 
       if(item.command){
         item.click = function(){
-          self.emit(item.command);
+          self.emit(item.command, item);
         }
       }
 


### PR DESCRIPTION
Fixes #47 by establishing a default "text context menu" that gets shown when you right click on text in the `channel__scrollback` or the `channel__input`, with options like `isEditable` and `isRange` to enable/disable the right options, just like a native Mac context menu.

Also fixes #46 by showing spelling suggestions in that context menu, if you right-click a misspelt word.