### PR TITLE
Join password-protected channels, and specify channels that shouldn't be joined on startup

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -187,9 +187,9 @@ window.AppView = window.BackchatView.extend({
       var self = this;
       _.each(settings.servers, function(server){
         self.addServerButton(server.url, { disconnected: true });
-        _.each(server.channels, function(channelName){
-          self.addChannelButton(server.url, channelName, { unjoined: true });
-          self.addChannelView(server.url, channelName);
+        _.each(server.channels, function(channel){
+          self.addChannelButton(server.url, channel.name, { unjoined: true });
+          self.addChannelView(server.url, channel.name, { unjoined: true });
         });
       });
       // Add the user's specified keywords
@@ -269,18 +269,22 @@ window.AppView = window.BackchatView.extend({
   channelButtonViews: {}, // Keyed by serverUrl+channelName
   keywords: [], // Words that should trigger a notification
 
-  addChannelView: function(serverUrl, channelName){
+  addChannelView: function(serverUrl, channelName, extraOptions){
     var id = serverUrl + ' ' + channelName;
 
     if(id in this.channelViews){
       return this.channelViews[id];
     }
 
-    var channelView = new window.ChannelView({
+    var options = _.extend({
       serverUrl: serverUrl,
       channelName: channelName
-    });
-    channelView.render().appendTo(this.$('.app-content'));
+    }, extraOptions);
+
+    var channelView = new window.ChannelView(options);
+    channelView.render().appendTo(
+      this.$('.app-content')
+    );
     this.channelViews[id] = channelView;
     return channelView;
   },
@@ -504,6 +508,11 @@ window.ChannelView = window.BackchatView.extend({
     this.$el.html(
       renderTemplate('channel')
     );
+
+    if(this.options.unjoined == true){
+      this.leave();
+    }
+
     return this.$el;
   },
 

--- a/src/templates/default-settings.json
+++ b/src/templates/default-settings.json
@@ -7,8 +7,15 @@
       "nick": "nodebot122",
       "userName": "nodebot122",
       "realName": "Node Bot 122",
-      "autoConnect": true,
-      "channels": [ "#bots" ]
+      "channels": [
+        {
+          "name": "#bots",
+          "autoJoin": false
+        },
+        {
+          "name": "#poplus"
+        }
+      ]
     }
   ],
   "keywords": [ "tannoy" ]

--- a/src/templates/test-settings.json
+++ b/src/templates/test-settings.json
@@ -7,8 +7,11 @@
       "nick": "backchat",
       "userName": "backchat",
       "realName": "Backchat",
-      "autoConnect": true,
-      "channels": [ "#channel1" ]
+      "channels": [
+        {
+          "name": "#channel1"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes #53 by letting you join password protected channels, either via `settings.json`, or text messages like `/join #some-channel some-password`. A new `.joinChannel()` function monkey-patches node-irc’s lack of channel password support, and is used throughout the server-side code, whenever we want to join a channel.

Fixes #54 by letting you specify `"autoJoin": false` in `settings.json`, for channels you want to remain unjoined on startup.

A server's channels are now stored as a list of objects in `settings.json`, rather than a list of strings (channelNames). This means we could have other per-channel settings in future, just by adding new keys to the channel objects.